### PR TITLE
fixed bug related with sequence position on tolerated touches

### DIFF
--- a/games/017_Simon/src/simon.cpp
+++ b/games/017_Simon/src/simon.cpp
@@ -501,9 +501,6 @@ bool playSimon(){
           if (lucky){
             Log.info("Touch tollerated, ignoring touch");
 
-            // we got lucky, lets redo this one by decreasing sequence_pos
-            sequence_pos--;
-
             // on level 2 and 3 we flash the correct pad on a miss
             if(currentLevel == 2 || currentLevel == 3){
               Log.info("Giving post-cue");


### PR DESCRIPTION
This PR fixes a bug introduced in #11 

I forgot to remove some code which resulted in the `sequence_pos` to be diminished twice