### PR TITLE
added commas in targetSeq

### DIFF
--- a/games/017_Simon/src/simon.cpp
+++ b/games/017_Simon/src/simon.cpp
@@ -588,6 +588,7 @@ bool playSimon(){
     extra += "\"targetSeq\":\"";
     for (int i = 0; i < sequenceLength; ++i){
         extra += convertBitfieldToLetter(touchpad_sequence[i]);
+        if (i < (sequenceLength -1)){extra += ",";}
     }
     extra += "\",\"touchSeq\":\"";
     for (int i = 0; i < touchLogIndex; ++i){


### PR DESCRIPTION
This PR adds commas to the `targetSeq` reporting for consistency. 