### PR TITLE
[Symon] fixed minimum level down amount (10)

### DIFF
--- a/games/017_Symon/src/symon.cpp
+++ b/games/017_Symon/src/symon.cpp
@@ -713,7 +713,7 @@ bool playSymon(){
     currentLevel++;
     resetPerformanceHistory();
   } else if (countMisses() >= TOO_MANY_MISSES) {
-    if (currentLevel > 1)
+    if (currentLevel > 10)
     {
       Log.info("Decreasing level! %u", currentLevel);
       currentLevel--;


### PR DESCRIPTION
The minimum level on the Symon game is 10.

This PR makes sure that we can't level down lower than 10.